### PR TITLE
implement docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# enables cuda support in docker
+FROM nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
+
+# install python 3.6, pip and requirements for opencv-python 
+# (see https://github.com/NVIDIA/nvidia-docker/issues/864)
+RUN apt-get update && apt-get -y install \
+    python3 \
+    python3-pip \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# install python dependencies
+RUN pip3 install torch~=1.2 torchvision opencv-python~=3.4
+
+# copy inference code
+WORKDIR /opt/MiDaS
+COPY ./midas ./midas
+COPY ./*.py ./
+
+# download model weights so the docker image can be used offline
+RUN curl -OL https://github.com/intel-isl/MiDaS/releases/download/v2/model-f46da743.pt
+RUN python3 run.py; exit 0
+
+# entrypoint (dont forget to mount input and output directories)
+CMD python3 run.py

--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ file in the root folder.
 
 3) The resulting inverse depth maps are written to the `output` folder.
 
+#### via Docker
+
+1) Make sure you have installed Docker and the
+   [NVIDIA Docker runtime](https://github.com/NVIDIA/nvidia-docker/wiki/Installation-\(Native-GPU-Support\)).
+
+2) Build the Docker image:
+
+    ```shell
+    docker build -t midas .
+    ```
+
+3) Run inference:
+
+    ```shell
+    docker run --rm --gpus all -v $PWD/input:/opt/MiDaS/input -v $PWD/output:/opt/MiDaS/output midas
+    ```
+
+   This command passes through all of your NVIDIA GPUs to the container, mounts the
+   `input` and `output` directories and then runs the inference.
 
 ### Citation
 


### PR DESCRIPTION
This adds a simple Dockerfile for packaging the code and model weights into a docker image.
Inference can then be achieved by running:
`docker build -t midas .` and `docker run --gpus all -v $PWD/input:/opt/MiDaS/input -v $PWD/output:/opt/MiDaS/output midas`